### PR TITLE
add velodyne install

### DIFF
--- a/beam_dependencies_install.bash
+++ b/beam_dependencies_install.bash
@@ -429,3 +429,26 @@ install_ladybug_sdk()
         echo "Ladybug SDK successfully installed in /usr/local/"
     fi
 }
+
+install_velodyne()
+{
+  VELODYNE_DIR="velodyne"
+  BUILD_DIR="build"
+  mkdir -p $DEPS_DIR
+  cd $DEPS_DIR
+
+  if [ ! -d "$VELODYNE_DIR" ]; then
+    git clone git@github.com:BEAMRobotics/velodyne.git
+  fi
+
+  cd $VELODYNE_DIR
+  if [ ! -d "$BUILD_DIR" ]; then
+    mkdir -p $BUILD_DIR
+    cd $BUILD_DIR
+    cmake ..
+    make -j$(nproc)
+  fi
+
+  cd $DEPS_DIR/$VELODYNE_DIR/$BUILD_DIR
+  sudo make -j$(nproc) install
+}


### PR DESCRIPTION
This install is necessary for unpack_velodyne_scans, which has been included in map_processing within beam_robotics