### PR TITLE
fix cmake install bug which occurs upon re-install

### DIFF
--- a/beam_dependencies_install.bash
+++ b/beam_dependencies_install.bash
@@ -314,7 +314,7 @@ install_cmake()
     sudo rm -rf /usr/local/cmake*
   fi
 
-  # remove cmake symlink if it exists. This is necessary if doing a re-install
+  #Remove CMake symlink if it exists. This is necessary if doing a re-install
   CMAKE_SYMLINK_PATH="/usr/local/bin/cmake"
   if [[ -h "$CMAKE_SYMLINK_PATH" ]]; then
     echo "Removing existing CMAKE symbolic link: $CMAKE_SYMLINK_PATH"


### PR DESCRIPTION
fix to check whether or not a symbolic link for CMake exists in /usr/local/bin and, if so, remove it prior to CMake install. 