### PR TITLE
add manif install (not sophus)

### DIFF
--- a/beam_dependencies_install.bash
+++ b/beam_dependencies_install.bash
@@ -540,3 +540,28 @@ install_pytorch_cuda()
   fi
 }
 
+install_manif()
+{
+  MANIF_DIR="Manif"
+  BUILD_DIR="build"
+  mkdir -p $DEPS_DIR
+  cd $DEPS_DIR
+
+  apt-get install libeigen3-dev
+  if [ ! -d "$MANIF_DIR" ]; then
+    git clone https://github.com/artivis/manif.git $DEPS_DIR/$MANIF_DIR
+  fi
+
+  cd $MANIF_DIR
+  if [ ! -d "$BUILD_DIR" ]; then
+    mkdir -p $BUILD_DIR
+    cd $BUILD_DIR
+    cmake ..
+    make install
+  fi
+
+  cd $DEPS_DIR/$MANIF_DIR/$BUILD_DIR
+  sudo make install
+}
+
+}


### PR DESCRIPTION
@nickcharron I have added the install for Manif to our installation of beam robotics. My idea is to have all dependencies from other packages within "BEAMRobotics" rely on "beam_robotics" itself, that way we can build off of the existing install workflow. 