### PR TITLE
Fix ig handle install

### DIFF
--- a/robot_dependencies_install.bash
+++ b/robot_dependencies_install.bash
@@ -148,7 +148,7 @@ install_arduino_teensyduino() {
   echo "TeensyduinoInstall: When prompted to 'Select Arduino Folder', enter $ARDUINO_TEENSYDUINO_INSTALL_DIR/arduino-1.8.13"
   sudo ./TeensyduinoInstall.linux64
 
-  # build core libraries for teensy3 and teensy4
+  # build core libraries for teensy3
   cd $ARDUINO_TEENSYDUINO_INSTALL_DIR/arduino-1.8.13/hardware/teensy/avr/cores/teensy3
   sudo make -j$NUM_PROCESSORS >/dev/null
 

--- a/robot_dependencies_install.bash
+++ b/robot_dependencies_install.bash
@@ -23,10 +23,10 @@ install_husky_packages() {
 }
 
 install_ig_handle() {
-  IG_HANDLE_DIR="ig_handle"
   cd $CATKIN_DIR/src/
   echo "Installing ig-handle driver and dependencies..."
 
+  IG_HANDLE_DIR="ig_handle"
   if [ ! -d "$IG_HANDLE_DIR" ]; then
     echo "$IG_HANDLE_DIR does not exist, cloning driver..."
     git clone git@github.com:BEAMRobotics/ig_handle.git
@@ -72,6 +72,14 @@ install_spinnaker_sdk() {
 
   cd $SP_SDK_DIR
   sudo sh install_spinnaker.sh
+
+  FLIR_CAMERA_DRIVER_DIR="flir_camera_driver"
+  if [ ! -d "$FLIR_CAMERA_DRIVER_DIR" ]; then
+    echo "$FLIR_CAMERA_DRIVER_DIR does not exist, cloning driver..."
+    git@github.com:ros-drivers/flir_camera_driver.git
+  else
+    echo "$FLIR_CAMERA_DRIVER_DIR exists."
+  fi
 }
 
 install_mti_sdk() {

--- a/robot_dependencies_install.bash
+++ b/robot_dependencies_install.bash
@@ -73,6 +73,7 @@ install_spinnaker_sdk() {
   cd $SP_SDK_DIR
   sudo sh install_spinnaker.sh
 
+  cd $CATKIN_DIR/src/
   FLIR_CAMERA_DRIVER_DIR="flir_camera_driver"
   if [ ! -d "$FLIR_CAMERA_DRIVER_DIR" ]; then
     echo "$FLIR_CAMERA_DRIVER_DIR does not exist, cloning driver..."

--- a/robot_dependencies_install.bash
+++ b/robot_dependencies_install.bash
@@ -77,7 +77,7 @@ install_spinnaker_sdk() {
   FLIR_CAMERA_DRIVER_DIR="flir_camera_driver"
   if [ ! -d "$FLIR_CAMERA_DRIVER_DIR" ]; then
     echo "$FLIR_CAMERA_DRIVER_DIR does not exist, cloning driver..."
-    git@github.com:ros-drivers/flir_camera_driver.git
+    git clone git@github.com:ros-drivers/flir_camera_driver.git
   else
     echo "$FLIR_CAMERA_DRIVER_DIR exists."
   fi

--- a/robot_dependencies_install.bash
+++ b/robot_dependencies_install.bash
@@ -151,8 +151,10 @@ install_arduino_teensyduino() {
   # build core libraries for teensy3 and teensy4
   cd $ARDUINO_TEENSYDUINO_INSTALL_DIR/arduino-1.8.13/hardware/teensy/avr/cores/teensy3
   sudo make -j$NUM_PROCESSORS >/dev/null
-  cd $ARDUINO_TEENSYDUINO_INSTALL_DIR/arduino-1.8.13/hardware/teensy/avr/cores/teensy4
-  sudo make -j$NUM_PROCESSORS >/dev/null
+
+  # build core libraries for teensy4 (ig-handle currently does not support teensy4)
+  # cd $ARDUINO_TEENSYDUINO_INSTALL_DIR/arduino-1.8.13/hardware/teensy/avr/cores/teensy4
+  # sudo make -j$NUM_PROCESSORS >/dev/null
 
   # install arduino IDE and setup udev rules
   cd $ARDUINO_TEENSYDUINO_INSTALL_DIR/arduino-1.8.13/

--- a/robot_dependencies_install.bash
+++ b/robot_dependencies_install.bash
@@ -67,10 +67,11 @@ install_spinnaker_sdk() {
     echo "Spinnaker SDK directory does not exist, downloading SDK..."
     gdown 1_nT47nHHy6ugRxHH4frLV29wgCRhSRGF
     tar fxv spinnaker-2.4.0.143-Ubuntu18.04-amd64-pkg.tar.gz
-    rm -rf spinnaker-2.4.0.143-Ubuntu18.04-amd64-pkg.tar.gz
   fi
 
+  # see installation wiki for correct input
   cd $SP_SDK_DIR
+  sudo sh remove_spinnaker.sh
   sudo sh install_spinnaker.sh
 
   cd $CATKIN_DIR/src/
@@ -95,20 +96,22 @@ install_mti_sdk() {
     echo "MTI SDK directory does not exist, downloading SDK..."
     gdown 1kTxxwwFHyDAJadEMhEjLIAN9_MnDgX-z
     tar xvf MT_Software_Suite_linux-x64_2021.2.tar.gz
-    rm -rf MT_Software_Suite_linux-x64_2021.2.tar.gz
+    cd $MT_SDK_DIR
+    tar xvf mtmanager_linux-x64_2021.2.tar.gz
+    tar xvf magfieldmapper_linux-x64_2021.2.tar.gz
+  else
+    cd $MT_SDK_DIR
   fi
 
-  cd $MT_SDK_DIR
-  tar xvf mtmanager_linux-x64_2021.2.tar.gz
-  tar xvf magfieldmapper_linux-x64_2021.2.tar.gz
-  rm -rf mtmanager_linux-x64_2021.2.tar.gz
-  rm -rf magfieldmapper_linux-x64_2021.2.tar.gz
+  # require user to enter default 'Xsens MT SDK' installation directory:
+  #   [/usr/local/xsens]
+  sudo sh mtsdk_linux-x64_2021.2.sh
 
-  chmod +x mtsdk_linux-x64_2021.2.sh
-  bash mtsdk_linux-x64_2021.2.sh
+  # create symbolic link for driver in catkin workspace
+  rm -rf $CATKIN_DIR/src/xsens_ros_mti_driver
+  ln -s /usr/local/xsens/xsens_ros_mti_driver $CATKIN_DIR/src
 
-  # require user to enter default 'Xsens MT SDK' installation directory
-  ln -s /usr/local/xsens/xsens_ros_mti_driver $CATKIN_DIR
+  # build core library
   cd /usr/local/xsens/xsens_ros_mti_driver/lib/xspublic
   sudo make -j$NUM_PROCESSORS >/dev/null
 }


### PR DESCRIPTION
This PR addresses install issues with:
- install_spinnaker_sdk
- install_mti_sdk
- install_arduino_teensyduino
which are required by ig-handle (and ig2)